### PR TITLE
Changed scope of deferred variable in request function.

### DIFF
--- a/forceng.js
+++ b/forceng.js
@@ -312,8 +312,8 @@ angular.module('forceng', [])
 
             var method = obj.method || 'GET',
                 headers = {},
-                url = getRequestBaseURL();
-            deferred = $q.defer();
+                url = getRequestBaseURL(),
+                deferred = $q.defer();
 
             // dev friendly API: Add leading '/' if missing so url + path concat always works
             if (obj.path.charAt(0) !== '/') {


### PR DESCRIPTION
Fixed issue #5 where deferred response was being overwritten when responding to simultaneous requests due to the fact that it's scope was broader than the request function.