### PR TITLE
Deferred is being stored in the global scope

### DIFF
--- a/forceng.js
+++ b/forceng.js
@@ -312,7 +312,7 @@ angular.module('forceng', [])
 
             var method = obj.method || 'GET',
                 headers = {},
-                url = getRequestBaseURL();
+                url = getRequestBaseURL(),
             deferred = $q.defer();
 
             // dev friendly API: Add leading '/' if missing so url + path concat always works


### PR DESCRIPTION
It's missing a comma and not a semicolon; this breaks promises that are being shared as mentioned in #9 