### PR TITLE
Kept the previous return data object

### DIFF
--- a/forceng.js
+++ b/forceng.js
@@ -339,7 +339,11 @@ angular.module('forceng', [])
         data: obj.data
       })
         .success(function (data, status, headers, config) {
-          deferred.resolve(data);
+          var response = data;
+          if (response.data) {
+              response = response.data;
+          }
+          deferred.resolve(response);
         })
         .error(function (data, status, headers, config) {
           if (status === 401 && oauth.refresh_token) {


### PR DESCRIPTION
$HTTP returns different response object. In order to keep the current mobile code, we will need use the previous response data.